### PR TITLE
Fix DOM tree re-rendering all nodes.

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -1,0 +1,7 @@
+import directives from './directives.js'
+
+export default (model) => {
+  let runInnerDirective = directives(model)
+
+  return (model, path) => runInnerDirective(model, path)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 import model from "./model.js"
-import { attachDirectives } from "./directives.js"
+import dom from "./dom.js"
 
 export default (data) => {
-  let runInnerDirective = null
+  let updateDOM = null
 
-  const app = model(data, () => runInnerDirective())
-
-  runInnerDirective = attachDirectives(app)
+  const app = model(data, (path) => updateDOM(app, path))
+  updateDOM = dom(app)
 
   return app
 }

--- a/src/model.js
+++ b/src/model.js
@@ -1,30 +1,8 @@
-const getAll = (name) =>
-  document.querySelectorAll(name ? `[k-model="${name}"]` : "[k-model]")
-
-const updateModel = (value, name) =>
-  getAll(name).forEach(
-    (element) =>
-      (element.value =
-        typeof value !== "string" ? JSON.stringify(value) : value)
-  )
-
-const setupModels = (model) => {
-  getAll().forEach((element) => {
-    const modelName = element.getAttribute("k-model")
-    updateModel(model[modelName] || "", modelName)
-    element.oninput = () => (model[modelName] = element.value)
-  })
-  return model
-}
-
-export default (data, callback) => setupModels(
-  new Proxy(data, {
-    get: (target, path) => target[path],
-    set: (target, path, value) => {
-      data[path] = value
-      updateModel(data[path], path)
-      callback(data)
-      return true
-    }
-  })
-)
+export default (data, callback) => new Proxy(data, {
+  get: (target, path) => target[path],
+  set: (_, path, value) => {
+    data[path] = value
+    callback(path)
+    return true
+  }
+})

--- a/src/node.js
+++ b/src/node.js
@@ -1,0 +1,5 @@
+export default (element) => ({
+  node: element,
+  path: element.getAttribute("k-bind")
+})
+

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,0 +1,7 @@
+export const valueToText = (data, value) => {
+  if (typeof value === "function") return value.call(data)
+  if (typeof value === "object") return JSON.stringify(value)
+  return value
+}
+
+export const get = (selector) => [...document.querySelectorAll(selector)]


### PR DESCRIPTION
The problem was fixed without the solution given in the issue.  
It made the HTML code become cluttered:  

**Before**:

```html
<p k-text="name"></p>
<input k-bind="name"/>
```

**After**:

```html
<p k-text="name" k-0></p>
<input k-bind="name" k-0/>
```

After considering how difficult can be to read after adding classes, ids... the solution was to move the model layer to a directive (as it should be), and when the state changes, get the changed path and update all nodes that uses that path.

Now, all nodes that use the same data, are changed. All that don't, are not.

closes #1